### PR TITLE
#75 add single sample parameter api

### DIFF
--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -162,7 +162,7 @@ components:
           pattern: '^[a-zA-Z0-9]{2,}'
         
         units: 
-          description: The units for the parameter data elements in a given column
+          description: The units for the parameter data values in a given column
           type: string
         
         dataType:
@@ -178,34 +178,12 @@ components:
       items: 
         $ref: '#/components/schemas/DataSample'
         
-
-    DataElement:
-      type: object
-      properties:
-        value:
-          description: The magnitude of the data value described in string form
-          type: string
-          
-        quality: 
-          description: The quality ratio of the data value (bounded from 0.0 to 1.0)
-          type: number          
-          format: double
-          minimum: 0.0
-          maximum: 1.0
-        
-        annotation: 
-          description: The annotation for the data value
-          type: string
-          
-      required:
-        - value        
-        
     DataSample:
-      description: A row of data elements described by the column definition, associated with a single discrete timestamp
+      description: A row of data values described by the column definition, associated with a single discrete timestamp
       type: object
       properties:
         timestamp:
-          description: the timestamp of the data elements
+          description: the timestamp of the data values
           type: string
           format: date-time
             
@@ -213,11 +191,10 @@ components:
           description: Must have the same length as the ColumnDefinition array
           type: array
           items:
-            $ref: '#/components/schemas/DataElement'
-            
-      required:
-        - timestamp
-        - fields
+            properties:
+              value:
+                description: The magnitude of the data value described in string form
+                type: string
 
     DataType:
       type: string

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -89,7 +89,7 @@ paths:
               $ref: '#/components/schemas/SingleDataDefinition'
       responses:
         201:
-          description: POSTed new time series parameter data
+          description: POSTed new single parameter data sample
           content:
             application/json:
               schema:
@@ -153,10 +153,10 @@ components:
         timestamp:
           type: string
           format: date-time
-          description: The timestamp the applies to the measurements in the data field (DataSample)
+          description: The timestamp that applies to the measurements in the data field (DataSample)
           
         data: 
-          description: A row of one or more data values, associated with a single discrete timestamp. The fields within this object should always follow a consistent order from request to request. Key/value pairs should be used, including units in the key name
+          description: A row of one or more data values, associated with a single discrete timestamp. Key/value pairs should be used, including units in the key name. The fields within this object should always follow a consistent order from row to row given a combination of messageType and version
           type: object
           additionalProperties: true    
         
@@ -188,7 +188,7 @@ components:
 
     SingleDataDefinition:
       type: object
-      description: A definition of a set of parameter data having a single discrete timestamp. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. 
+      description: A definition of a set of parameter data having a single discrete timestamp. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys
       properties:
 
         header:

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -200,7 +200,7 @@ components:
 
     TimeSeriesDataDefinition:
       type: object
-      description: A time series collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order from data sample row to data sample row. Note: Time series data will be sorted by the server if not following order of occurence
+      description: A time series collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order from data sample row to data sample row. Time series data will be sorted by the server if not following order of occurence
       properties:
 
         header:

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -176,14 +176,36 @@ components:
       description: The time series data, an ordered collection relative to the timestamp field
       type: array
       items: 
-        $ref: '#/components/schemas/DataElements'
+        $ref: '#/components/schemas/DataSample'
         
-    DataElements:
-      description: A row of data elements described by the column definition, associated with a discrete timestamp
+
+    DataElement:
+      type: object
+      properties:
+        value:
+          description: The magnitude of the data value described in string form
+          type: string
+          
+        quality: 
+          description: The quality ratio of the data value (bounded from 0.0 to 1.0)
+          type: number          
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+        
+        annotation: 
+          description: The annotation for the data value
+          type: string
+          
+      required:
+        - value        
+        
+    DataSample:
+      description: A row of data elements described by the column definition, associated with a single discrete timestamp
       type: object
       properties:
         timestamp:
-          description: the timestamp of the sample
+          description: the timestamp of the data elements
           type: string
           format: date-time
             
@@ -221,7 +243,7 @@ components:
 
     SingleDataDefinition:
       type: object
-      description: A definition of a single parameter data sample. 
+      description: A definition of a set of parameter data having a single discrete timestamp
       properties:
 
         header:
@@ -231,7 +253,7 @@ components:
           $ref: '#/components/schemas/ColumnDefinition'
 
         data:
-          $ref: '#/components/schemas/DataElements'
+          $ref: '#/components/schemas/DataSample'
 
       required: 
         - header
@@ -256,27 +278,6 @@ components:
         - header
         - columns
         - data
-
-    DataElement:
-      type: object
-      properties:
-        value:
-          description: The value of the data sample described in string form
-          type: string
-          
-        quality: 
-          description: The quality ratio of the data sample (bounded from 0.0 to 1.0)
-          type: number          
-          format: double
-          minimum: 0.0
-          maximum: 1.0
-        
-        annotation: 
-          description: The annotation for the data sample
-          type: string
-          
-      required:
-        - value
         
   securitySchemes:
     ParameterDataDefinitionsAuth:      

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -144,117 +144,79 @@ components:
           description: The success message provided back to the client
       required:
         - message
-        
-    ColumnDefinition:
-      description: The definition of the columns of the parameter data. Must have the same length as the DataSample fields array
-      type: array
-      items:
-        $ref: '#/components/schemas/ColumnElement'
-          
-    ColumnElement:
-      type: object
-      description: The column element
-      properties:
-        
-        name: 
-          description: The name of the column
-          type: string
-          pattern: '^[a-zA-Z0-9]{2,}'
-        
-        units: 
-          description: The units for the parameter data values in a given column
-          type: string
-        
-        dataType:
-          $ref: '#/components/schemas/DataType'
-                   
-      required:
-        - name
-        - dataType
 
-    DataDefinition:
-      description: The time series data, an ordered collection relative to the timestamp field
-      type: array
-      items: 
-        $ref: '#/components/schemas/DataSample'
-        
     DataSample:
-      description: A row of data values described by the column definition, associated with a single discrete timestamp
       type: object
+      description: A definition of a set of parameter data having a single discrete timestamp
       properties:
+      
         timestamp:
-          description: the timestamp of the data values
           type: string
           format: date-time
-            
-        fields:
-          description: Must have the same length as the ColumnDefinition array
-          type: array
-          items:
-            properties:
-              value:
-                description: The magnitude of the data value described in string form
-                type: string
-
-    DataType:
-      type: string
-      enum:
-        - NUMBER
-        - INTEGER
-        - STRING
+          description: The timestamp the applies to the measurements in the data field (DataSample)
+          
+        data: 
+          description: A row of one or more data values, associated with a single discrete timestamp. The fields within this object should always follow a consistent order from request to request. Key/value pairs should be used, including units in the key name
+          type: object
+          additionalProperties: true    
         
+      required:
+        - timestamp
+        - data    
+
     HeaderDefinition:
       type: object
       properties: 
+      
+        componentUuid:
+          type: string
+          format: uuid
+          description: The unique identifier of the component within FRAIHMWORK that the parameter data associates with
+      
         messageType:
           type: string          
-          description: The type of the message
+          description: The type of the message, dictated by the client for delineating individual message formats
 
         messageVersion:
           type: string
-          description: The version string for the parameter data messageType
+          description: The version string for the parameter data messageType. If the client changes the data fields within a message stream, they should increment the version accordingly to distinguish message format along with the messageType
           
       required:
+        - componentUuid
         - messageType
         - version
 
     SingleDataDefinition:
       type: object
-      description: A definition of a set of parameter data having a single discrete timestamp
+      description: A definition of a set of parameter data having a single discrete timestamp. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. 
       properties:
 
         header:
           $ref: '#/components/schemas/HeaderDefinition'
-          
-        columns:
-          $ref: '#/components/schemas/ColumnDefinition'
 
-        data:
+        single:
           $ref: '#/components/schemas/DataSample'
-
+         
       required: 
         - header
-        - columns
-        - data
+        - single
 
     TimeSeriesDataDefinition:
       type: object
-      description: A definition of time series data. This is loosely based upon Json Time Series, Version 1.0 (https://docs.eagle.io/en/latest/reference/index.html)
+      description: A time series ordered collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order
       properties:
 
         header:
           $ref: '#/components/schemas/HeaderDefinition'
-          
-        columns:
-          $ref: '#/components/schemas/ColumnDefinition'
 
-        data:
-          $ref: '#/components/schemas/DataDefinition'
-
+        series:
+          type: array
+          items: 
+            $ref: '#/components/schemas/DataSample'
+                        
       required: 
         - header
-        - columns
-        - data
+        - series
         
   securitySchemes:
     ParameterDataDefinitionsAuth:      

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -200,7 +200,7 @@ components:
 
     TimeSeriesDataDefinition:
       type: object
-      description: A time series collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order from data sample row to data sample row. Time series data will be sorted by the server if not following order of occurence
+      description: A time series collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order from data sample row to data sample row. Time series data will be sorted by the server if not following order of occurrence
       properties:
 
         header:

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -5,7 +5,7 @@ info:
   description: 'FRAIHMWORK allows for time series or single sample parameter data to be provided from the client. This API will be versioned according to SemVer 2.0 rules (as described here: https://semver.org/)'
   contact:
     email: matt.synborski@resilienx.com
-  version: 1.0.0
+  version: 0.1.0
 externalDocs:
   description: Find out more about Swagger
   url: http://swagger.io

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -2,10 +2,10 @@
 openapi: 3.0.1
 info:
   title: FRAIHMWORK Parameter Data API
-  description: 'FRAIHMWORK allows for parameter time-series data to be provided from the client. This API will be versioned according to SemVer 2.0 rules (as described here: https://semver.org/)'
+  description: 'FRAIHMWORK allows for time series or single sample parameter data to be provided from the client. This API will be versioned according to SemVer 2.0 rules (as described here: https://semver.org/)'
   contact:
     email: matt.synborski@resilienx.com
-  version: 0.0.1
+  version: 1.0.0
 externalDocs:
   description: Find out more about Swagger
   url: http://swagger.io
@@ -18,13 +18,13 @@ tags:
   description: Parameter data model manipulation endpoints
 
 paths:
-  /parameter:
+  /timeSeries:
     post:
       tags:
         - Parameter
-      summary: Add new time series parameter data to FRAIHMWORK model
-      description: Add new time series parameter data to FRAIHMWORK model
-      operationId: registerParameterData
+      summary: Add new time series of parameter data to FRAIHMWORK model.
+      description: Add new time series of parameter data to FRAIHMWORK model.
+      operationId: registerParameterDataSeries
       requestBody:
         required: true
         content:
@@ -40,7 +40,7 @@ paths:
                 $ref: '#/components/schemas/Response'
           
         400:
-          description: Bad Request (invalid submission). 
+          description: Bad Request (invalid submission)
           content:
             application/json:
               schema:
@@ -73,6 +73,62 @@ paths:
       security:
       - ParameterDataDefinitionsAuth:
         - fraihmwork.parameter.data.write
+        
+  /sample:
+    post:
+      tags:
+        - Parameter
+      summary: Add new timestamped sample of parameter data to FRAIHMWORK model.
+      description: Add new timestamped sample of parameter data to FRAIHMWORK model.
+      operationId: registerParameterDataSample
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SingleDataDefinition'
+      responses:
+        201:
+          description: POSTed new time series parameter data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+          
+        400:
+          description: Bad Request (invalid submission)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+          
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - ParameterDataDefinitionsAuth:
+        - fraihmwork.parameter.data.write        
 
 components:
   schemas:
@@ -92,11 +148,11 @@ components:
     ColumnDefinition:
       type: array
       items:
-        $ref: '#/components/schemas/ColumnElementDefinition'
+        $ref: '#/components/schemas/ColumnElement'
           
-    ColumnElementDefinition:
+    ColumnElement:
       type: object
-      description: The column elements      
+      description: The column elements.
       properties:
         
         name: 
@@ -149,16 +205,15 @@ components:
           format: date-time
         
         endTime: 
-          description: The end time for the time series
+          description: The end time for the time series.
           type: string
           format: date-time
         
         recordCount: 
-          description: The number of records in the data.
+          description: The number of records in the data
           type: integer
           
-        columns:
-          $ref: '#/components/schemas/ColumnDefinition'
+
         
       required:
         - startTime
@@ -166,42 +221,73 @@ components:
         - recordCount
         - columns
 
+    SingleDataDefinition:
+      type: object
+      description: A definition of a single parameter data sample. This is loosely based upon Json Time Series, Version 1.0. (https://docs.eagle.io/en/latest/reference/index.html)
+      properties:
+        messageType:
+          type: string          
+          description: The type of the message.
+
+        version:
+          type: string
+          description: The version string for the parameter data messageType.
+
+        header:
+          $ref: '#/components/schemas/HeaderDefinition'
+          
+        columns:
+          $ref: '#/components/schemas/ColumnDefinition'          
+
+        data:
+          $ref: '#/components/schemas/DataElement'
+
+      required: 
+        - messageType
+        - header
+        - columns
+        - data
+
     TimeSeriesDataDefinition:
       type: object
       description: A definition of time series data. This is loosely based upon Json Time Series, Version 1.0. (https://docs.eagle.io/en/latest/reference/index.html)
       properties:
-        docType:
+        messageType:
           type: string          
-          description: The type of the document
+          description: The type of the message.
 
         version:
           type: string
-          description: The version string for the time series data definition
+          description: The version string for the parameter data messageType.
 
         header:
           $ref: '#/components/schemas/HeaderDefinition'
+          
+        columns:
+          $ref: '#/components/schemas/ColumnDefinition'
 
         data:
           $ref: '#/components/schemas/DataDefinition'
 
       required: 
-        - docType
+        - messageType
         - header
+        - columns
         - data
 
     ValueSpec:
       type: object
       properties:
         value:
-          description: The value of the data sample described in string form. 
+          description: The value of the data sample described in string form
           type: string
           
         quality: 
-          description: The quality score of the data sample (should be bounded 0.0 .. 100.0)
+          description: The quality score of the data sample (should be bounded 0.0 .. 1.0)
           type: number          
           format: double
           minimum: 0.0
-          maximum: 100.0
+          maximum: 1.0
         
         annotation: 
           description: The annotation for the data sample

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -22,8 +22,8 @@ paths:
     post:
       tags:
         - Parameter
-      summary: Add new time series of parameter data to FRAIHMWORK model.
-      description: Add new time series of parameter data to FRAIHMWORK model.
+      summary: Add new time series of parameter data to FRAIHMWORK model
+      description: Add new time series of parameter data to FRAIHMWORK model
       operationId: registerParameterDataSeries
       requestBody:
         required: true
@@ -78,8 +78,8 @@ paths:
     post:
       tags:
         - Parameter
-      summary: Add new timestamped sample of parameter data to FRAIHMWORK model.
-      description: Add new timestamped sample of parameter data to FRAIHMWORK model.
+      summary: Add new timestamped sample of parameter data to FRAIHMWORK model
+      description: Add new timestamped sample of parameter data to FRAIHMWORK model
       operationId: registerParameterDataSample
       requestBody:
         required: true
@@ -205,7 +205,7 @@ components:
 
         messageVersion:
           type: string
-          description: The version string for the parameter data messageType.
+          description: The version string for the parameter data messageType
           
       required:
         - messageType
@@ -213,7 +213,7 @@ components:
 
     SingleDataDefinition:
       type: object
-      description: A definition of a single parameter data sample. This is loosely based upon Json Time Series, Version 1.0. (https://docs.eagle.io/en/latest/reference/index.html)
+      description: A definition of a single parameter data sample. This is loosely based upon Json Time Series, Version 1.0 (https://docs.eagle.io/en/latest/reference/index.html)
       properties:
 
         header:
@@ -232,7 +232,7 @@ components:
 
     TimeSeriesDataDefinition:
       type: object
-      description: A definition of time series data. This is loosely based upon Json Time Series, Version 1.0. (https://docs.eagle.io/en/latest/reference/index.html)
+      description: A definition of time series data. This is loosely based upon Json Time Series, Version 1.0 (https://docs.eagle.io/en/latest/reference/index.html)
       properties:
 
         header:

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -150,18 +150,18 @@ components:
       description: A definition of a set of parameter data having a single discrete timestamp
       properties:
       
-        timestamp:
+        timeOfApplicability:
           type: string
           format: date-time
-          description: The timestamp that applies to the measurements in the data field (DataSample)
+          description: The time at which the parameter data value or values are measured or sampled
           
         data: 
-          description: A row of one or more data values, associated with a single discrete timestamp. Key/value pairs should be used, including units in the key name. The fields within this object should always follow a consistent order from row to row given a combination of messageType and version
+          description: A row of one or more data values, associated with a single discrete timestamp. Key/value pairs should be used, including units in the key name. The fields within this object should always follow a consistent order from row to row given a combination of messageType and messageVersion
           type: object
           additionalProperties: true    
         
       required:
-        - timestamp
+        - timeOfApplicability
         - data    
 
     HeaderDefinition:
@@ -184,26 +184,23 @@ components:
       required:
         - componentUuid
         - messageType
-        - version
+        - messageVersion
 
     SingleDataDefinition:
       type: object
       description: A definition of a set of parameter data having a single discrete timestamp. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys
-      properties:
-
-        header:
-          $ref: '#/components/schemas/HeaderDefinition'
-
-        single:
-          $ref: '#/components/schemas/DataSample'
-         
-      required: 
-        - header
-        - single
+      allOf:
+      
+      - type: object
+        properties:          
+          header:
+            $ref: '#/components/schemas/HeaderDefinition'
+            
+      - $ref: '#/components/schemas/DataSample'
 
     TimeSeriesDataDefinition:
       type: object
-      description: A time series ordered collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order
+      description: A time series collection for a set of parameter data. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys. It is encouraged that each element in the array has the same keys in the same order from data sample row to data sample row. Note: Time series data will be sorted by the server if not following order of occurence
       properties:
 
         header:

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -152,7 +152,7 @@ components:
           
     ColumnElement:
       type: object
-      description: The column elements.
+      description: The column element.
       properties:
         
         name: 
@@ -203,7 +203,7 @@ components:
           type: string          
           description: The type of the message.
 
-        version:
+        messageVersion:
           type: string
           description: The version string for the parameter data messageType.
           

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -152,7 +152,7 @@ components:
           
     ColumnElement:
       type: object
-      description: The column element.
+      description: The column element
       properties:
         
         name: 
@@ -201,7 +201,7 @@ components:
       properties: 
         messageType:
           type: string          
-          description: The type of the message.
+          description: The type of the message
 
         messageVersion:
           type: string
@@ -257,7 +257,7 @@ components:
           type: string
           
         quality: 
-          description: The quality score of the data sample (should be bounded 0.0 .. 1.0)
+          description: The quality ratio of the data sample (bounded from 0.0 to 1.0)
           type: number          
           format: double
           minimum: 0.0

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -190,13 +190,12 @@ components:
       type: object
       description: A definition of a set of parameter data having a single discrete timestamp. For multiple parameter observations for the given timestamp, use multiple key/value pairs with unique keys
       allOf:
-      
+      - $ref: '#/components/schemas/DataSample'      
       - type: object
         properties:          
           header:
             $ref: '#/components/schemas/HeaderDefinition'
-            
-      - $ref: '#/components/schemas/DataSample'
+
 
     TimeSeriesDataDefinition:
       type: object

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -18,7 +18,7 @@ tags:
   description: Parameter data model manipulation endpoints
 
 paths:
-  /timeSeries:
+  /series:
     post:
       tags:
         - Parameter
@@ -146,6 +146,7 @@ components:
         - message
         
     ColumnDefinition:
+      description: The definition of the columns of the parameter data. Must have the same length as the DataElements fields array
       type: array
       items:
         $ref: '#/components/schemas/ColumnElement'
@@ -159,7 +160,11 @@ components:
           description: The name of the column
           type: string
           pattern: '^[a-zA-Z0-9]{2,}'
-          
+        
+        units: 
+          description: The units for the parameter data elements in a given column
+          type: string
+        
         dataType:
           $ref: '#/components/schemas/DataType'
                    
@@ -168,11 +173,13 @@ components:
         - dataType
 
     DataDefinition:
+      description: The time series data, an ordered collection relative to the timestamp field
       type: array
       items: 
-        $ref: '#/components/schemas/DataElement'
+        $ref: '#/components/schemas/DataElements'
         
-    DataElement:
+    DataElements:
+      description: A row of data elements described by the column definition, associated with a discrete timestamp
       type: object
       properties:
         timestamp:
@@ -181,9 +188,10 @@ components:
           format: date-time
             
         fields:
+          description: Must have the same length as the ColumnDefinition array
           type: array
           items:
-            $ref: '#/components/schemas/ValueSpec'
+            $ref: '#/components/schemas/DataElement'
             
       required:
         - timestamp
@@ -213,17 +221,17 @@ components:
 
     SingleDataDefinition:
       type: object
-      description: A definition of a single parameter data sample. This is loosely based upon Json Time Series, Version 1.0 (https://docs.eagle.io/en/latest/reference/index.html)
+      description: A definition of a single parameter data sample. 
       properties:
 
         header:
           $ref: '#/components/schemas/HeaderDefinition'
           
         columns:
-          $ref: '#/components/schemas/ColumnDefinition'          
+          $ref: '#/components/schemas/ColumnDefinition'
 
         data:
-          $ref: '#/components/schemas/DataElement'
+          $ref: '#/components/schemas/DataElements'
 
       required: 
         - header
@@ -249,7 +257,7 @@ components:
         - columns
         - data
 
-    ValueSpec:
+    DataElement:
       type: object
       properties:
         value:

--- a/ParameterDataApi.yaml
+++ b/ParameterDataApi.yaml
@@ -146,7 +146,7 @@ components:
         - message
         
     ColumnDefinition:
-      description: The definition of the columns of the parameter data. Must have the same length as the DataElements fields array
+      description: The definition of the columns of the parameter data. Must have the same length as the DataSample fields array
       type: array
       items:
         $ref: '#/components/schemas/ColumnElement'

--- a/ParameterDataApiChangelist.txt
+++ b/ParameterDataApiChangelist.txt
@@ -1,3 +1,6 @@
+Version 1.0.0: 
+Overhaul of time series endpoint and constituent types. Addition of single data definition endpoint.
+
 Version 0.0.1: 
 Added docType field to required fields.
 

--- a/ParameterDataApiChangelist.txt
+++ b/ParameterDataApiChangelist.txt
@@ -1,5 +1,5 @@
 
-Version 1.0.0: 
+Version 0.1.0: 
 Overhaul of time series endpoint and simplified use of constituent data types. Addition of single data definition endpoint.
 
 Version 0.0.2: 

--- a/ParameterDataApiChangelist.txt
+++ b/ParameterDataApiChangelist.txt
@@ -1,6 +1,6 @@
 
 Version 1.0.0: 
-Overhaul of time series endpoint and constituent types. Addition of single data definition endpoint.
+Overhaul of time series endpoint and simplified use of constituent data types. Addition of single data definition endpoint.
 
 Version 0.0.2: 
 Removed recordCount field from HeaderDefinition fields.


### PR DESCRIPTION
The Parameter API Datatypes allow time series data to be provided to FRAIHMWORK. Currently, (shown in the from) there's a way to define the columns by name in the time series data. There is an implicit requirement for the "ColumnDefinition" array to be the same length as the DataElement.fields[] array, as the number of DataElement.fields[] array elements corresponds to the number of columns in the time series data.

In the proposed version of the API, we strip away the column datatypes and rely on key-value pairs within the DataSample type using additionalProperties: true and no other fields. This way, the client can send whatever name/value stuff they want, and we will deal with the unstructuredness when we write a schema for DIS, or when we write queries for Grafana, which are the two major use cases for this data when it is pushed to a database by the subsequent changes to the Parameter Streaming interface once this API is merged to develop.

Changing from:
![image](https://user-images.githubusercontent.com/78111776/218584011-0f92a01f-3cab-464e-b0cc-10c32711efb3.png)

To:
![image](https://user-images.githubusercontent.com/78111776/219691692-ec64d315-864f-41db-9fc9-b247018dfdf1.png)

