### PR TITLE
Incorporating the internal api specification into the external one, a…

### DIFF
--- a/FraihmworkHealthAndIntegrityApi.yaml
+++ b/FraihmworkHealthAndIntegrityApi.yaml
@@ -696,6 +696,116 @@ paths:
       security:
       - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
 
+  /monitor/v1/component/{uuid}/timeOfPerformance:
+    post:
+      tags:
+      - Components
+      - Monitor
+      summary: Resets the time of performance 
+      description: Given a specific component UUID, this operation establishes a new start time for the measurement of the 'time of performance' field tracked by components. When received, the server immediately sets the start time to the current clock time. Note, requests with the fraihmwork.component.write permission will only be accepted if the client used is the 'owner' of the component. Otherwise a 403 forbidden will be returned. See the descriptions in the securitySchemes.OAuth2.flows.clientCredentials.scopes for more details.     
+      operationId: resetTimeOfPerformance
+      parameters:
+        - in: path
+          name: uuid
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Uuid of the component for Time of Performance to be reset
+      responses:
+        200:
+          description: Time of performance successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+          
+        400:
+          description: Bad Request (invalid submission)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to reset this component's time of performance
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Target component could not be found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
+  /monitor/v1/component/{uuid}/timeOfReplacement:
+    post:
+      tags:
+      - Components
+      - Monitor
+      summary: Resets the time of replacement 
+      description: Given a specific component UUID, this operation establishes a new start time for the measurement of the 'time of replacement' field tracked by components. When received, the server immediately sets the start time to the current clock time. Note, requests with the fraihmwork.component.write permission will only be accepted if the client used is the 'owner' of the component. Otherwise a 403 forbidden will be returned. See the descriptions in the securitySchemes.OAuth2.flows.clientCredentials.scopes for more details.     
+      parameters:
+        - in: path
+          name: uuid
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Uuid of the component for Time of Replacement to be reset
+      responses:
+        200:
+          description: Time of replacement successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad Request (invalid submission)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to reset this component's time of replacement
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Target component could not be found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
   /monitor/v1/fault:
     post:
       tags:

--- a/FraihmworkHealthAndIntegrityApi.yaml
+++ b/FraihmworkHealthAndIntegrityApi.yaml
@@ -759,6 +759,7 @@ paths:
       - Monitor
       summary: Resets the time of replacement 
       description: Given a specific component UUID, this operation establishes a new start time for the measurement of the 'time of replacement' field tracked by components. When received, the server immediately sets the start time to the current clock time. Note, requests with the fraihmwork.component.write permission will only be accepted if the client used is the 'owner' of the component. Otherwise a 403 forbidden will be returned. See the descriptions in the securitySchemes.OAuth2.flows.clientCredentials.scopes for more details.     
+      operationId: resetTimeOfReplacement
       parameters:
         - in: path
           name: uuid

--- a/FraihmworkHealthAndIntegrityApi.yaml
+++ b/FraihmworkHealthAndIntegrityApi.yaml
@@ -682,7 +682,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         404:
-          description: UUID not found
+          description: Target component not found
           content: 
             application/json:
               schema:
@@ -720,14 +720,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
           
-        400:
-          description: Bad Request (invalid submission)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
         401:
-          description: Unauthorized
+          description: Not authenticated
           content:
             application/json:
               schema:
@@ -775,14 +769,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
-        400:
-          description: Bad Request (invalid submission)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
         401:
-          description: Unauthorized
+          description: Not authenticated
           content:
             application/json:
               schema:

--- a/FraihmworkHealthAndIntegrityApiChangelist.txt
+++ b/FraihmworkHealthAndIntegrityApiChangelist.txt
@@ -1,6 +1,7 @@
 Version 1.3.0
 - Moved Blocklister API elements to FraihmworkHealthAndIntegrityApi
 - Moved Mitigator API elements to FraihmworkHealthAndIntegrityApi
+- Added endpoints for resetting the timeOfPerformance and timeOfReplacement, previously only available in an internal api specification
 - Updated security scopes to follow convention in destination spec
 - Updated blocklister scopes to match read/write/admin pattern
 - Removed subscription elements from Blocklister API elements


### PR DESCRIPTION
…nd correcting a few inconsistencies on the way:

- Path corrected to be .../component/{uuid}/timeOf... instead of having the {uuid} part last
- Changed 201 response to be a 200 instead, since it is more accurate
- Added write/admin scope requirements to the two endpoints
- Added 401, 403, and 404 repsonses, removed 406

This review is effectively just inspection. C&P the new file into the swagger editor, confirm no issues and that everything looks ok.