### PR TITLE
111 adding the initial revision of the FRES API to the repository

### DIFF
--- a/FraihmworkRulesEngineApi.yaml
+++ b/FraihmworkRulesEngineApi.yaml
@@ -201,16 +201,16 @@ paths:
     get:
       tags:
       - Rule Instances
-      summary: Retrieve all the rule instances active in this FRAIHMWORK deployment, filtered by any optional criteria provided.
+      summary: Retrieve a specific rule instance using its unique identifier (UUID)
       operationId: findRuleInstanceByUuid
       parameters:
       - in: path
         name: uuid
+        description: UUID of the rule to retrieve
         required: true
         schema:
           type: string
           format: uuid
-        description: UUID of the rule to retrieve
       responses:
         200:
           description: OK
@@ -231,7 +231,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         400:
-          description: Bad Request
+          description: Bad request, likely due to malformed UUID input
           content:
             application/json:
               schema:
@@ -324,9 +324,10 @@ components:
         itemId:
           type: string
           format: uuid
+          description: UUID of the relevant resource, if applicable
         message:
           type: string
-          description: The success message provided back to the client
+          description: The message provided back to the client
       required:
         - message
         
@@ -349,10 +350,11 @@ components:
           description: The Rule Template that this instance is based on
         ruleProperties:
           type: object
+          additionalProperties: true
           description: A free-form object that MUST match the Rule Template's JSON schema rules to be accepted
       required:
-        - template
         - name
+        - template
         - ruleProperties
 
     RuleTemplate:
@@ -370,18 +372,15 @@ components:
         amqpRoutingKey:
           type: string
           description: Rules generated from this template will be applied to messages that arrive from this routing key
-        instanceSchema:
-          type: string
-          description: The JSON schema that is used for the generation of any rule instatiations of this template, as a string
-        dmnFile:
-          type: string
-          description: The Decision Model Notation file that processes the inputs and outputs of the rule as a string
+        ruleInstanceSchema:
+          type: object
+          additionalProperties: true
+          description: The JSON schema that is used for the generation of any rule instatiations of this template, as a free form object, since JSON Schemas are JSON
       required:
         - name
         - amqpExchange
         - amqpRoutingKey
-        - instanceSchema
-        - dmnFile
+        - ruleInstanceSchema
         
   securitySchemes:
     OAuth2:
@@ -395,6 +394,7 @@ components:
           tokenUrl: https://well-known/oauth-authorization-server/token
           refreshUrl: https://well-known/oauth-authorization-server/refresh
           scopes:
+            # As per requirements, the component scopes are to be used for the rules manipulation until further notice
             fraihmwork.component.admin: Client may create, read, update, or delete any component regardless of creator.
             fraihmwork.component.write: Client may create new components, but can only update and delete components they create. Client may read all components regardless of creator.
             fraihmwork.component.read: Client may read any component that FRAIHMWORK can provide, regardless of creator.

--- a/FraihmworkRulesEngineApi.yaml
+++ b/FraihmworkRulesEngineApi.yaml
@@ -1,0 +1,400 @@
+---
+openapi: 3.0.1
+info:
+  title: FRAIHMWORK Rules Engine Service API
+  description: 'As data moves through FRAIHMWORK, there are many reactions the system must take in order to ensure correct behavior across the ecosystem. This API allows for instantiations of rules to be implemented into the target deployment that allows some of these actions to be automated. This API will versioned according to SemVer 2.0.0 rules (as described here: https://semver.org/)'
+  contact:
+    email: g.dorchies@resilienx.com
+  version: 0.1.0
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+
+servers:
+- url: https://<site>.fraihmwork.resilienx.com/api
+
+tags:
+- name: Rule Instances
+  description: Functions relating to creating, modifying, reading, or deleting rule instances
+
+- name: Rule Templates
+  description: Functions relating to reading rule templates
+  
+paths:
+  /rules/v0/templates:
+    get:
+      tags:
+      - Rule Templates
+      summary: Retrieve all the rule templates active in this FRAIHMWORK deployment, filtered by any optional criteria provided.
+      operationId: findAllRuleTemplates
+      parameters:
+      - name: name
+        in: query
+        description: Filter results by the name of the rule. Can leave null to not filter on this parameter
+        schema:
+          type: string         
+      - name: exchange
+        in: query
+        description: Filter results by the AMQP exchange that the messages that the rule(s) apply to come from. Can leave null to not filter
+        schema:
+          type: string         
+      - name: routingKey
+        in: query
+        description: Filter results by the AMQP routing key that is used to select the messages that the rule(s) apply to. Can leave null to not filter
+        schema:
+          type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RuleTemplate'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to read rule templates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
+
+  /rules/v0/instances:
+    get:
+      tags:
+      - Rule Instances
+      summary: Retrieve all the rule instances active in this FRAIHMWORK deployment, filtered by any optional criteria provided.
+      operationId: findAllRuleInstances
+      parameters:
+      - name: template
+        in: query
+        description: Filter results by the name of the Rule Template that the target rules are based on. Can leave null to not filter on this parameter
+        schema:
+          type: string         
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RuleInstance'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to read rule instances
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
+
+    post:
+      tags:
+      - Rule Instances
+      summary: Post a new rule to the FRAIHMWORK deployment
+      operationId: postRuleInstance
+      requestBody:
+        description: JSON description of the new rule
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuleInstance'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to read rule instances
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad request, incoming JSON malformed or not matching template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
+
+  /rules/v0/instances/{uuid}:
+    get:
+      tags:
+      - Rule Instances
+      summary: Retrieve all the rule instances active in this FRAIHMWORK deployment, filtered by any optional criteria provided.
+      operationId: findRuleInstanceByUuid
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: UUID of the rule to retrieve
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleInstance'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to read rule instances
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Rule instance with specified UUID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
+    
+    delete:
+      tags:
+      - Rule Instances
+      summary: Deletes the target rule instance.
+      operationId: deleteRuleInstanceByUuid
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: UUID of the rule to delete
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to read rule instances
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Rule instance with specified UUID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
+
+components:
+  schemas:
+    Response:
+      type: object
+      properties:
+        itemId:
+          type: string
+          format: uuid
+        message:
+          type: string
+          description: The success message provided back to the client
+      required:
+        - message
+        
+    RuleInstance:
+      type: object
+      description: An instantiation of a rule template to be applied to specific input parameters matching the template's pre-defined schema
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          description: Unique identifier for the rule, assigned at creation
+        name: 
+          type: string
+          description: A name for the rule instance, to provide additional context
+        description:
+          type: string
+          description: An optional description of the rule instance, to provide additional context
+        template:
+          type: string
+          description: The Rule Template that this instance is based on
+        ruleProperties:
+          type: object
+          description: A free-form object that MUST match the Rule Template's JSON schema rules to be accepted
+      required:
+        - template
+        - name
+        - ruleProperties
+
+    RuleTemplate:
+      description: A template for a rule-based action that FRAIHMWORK can take in response to messages received from AMQP
+      properties:
+        name:
+          type: string
+          description: The name of the rule
+        description:
+          type: string
+          description: A description of the rule template
+        amqpExchange:
+          type: string
+          description: Rules generated from this template will affect messages that come from this AMQP exchange
+        amqpRoutingKey:
+          type: string
+          description: Rules generated from this template will be applied to messages that arrive from this routing key
+        instanceSchema:
+          type: string
+          description: The JSON schema that is used for the generation of any rule instatiations of this template, as a string
+        dmnFile:
+          type: string
+          description: The Decision Model Notation file that processes the inputs and outputs of the rule as a string
+      required:
+        - name
+        - amqpExchange
+        - amqpRoutingKey
+        - instanceSchema
+        - dmnFile
+        
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          # Note that multiple authorization servers can be specified to serve this API, and this description only provides details for the default
+          # internal security configuration. Each of the scopes below corresponds to a FRAIHMWORK permission, and can be configured to align to a 
+          # different scope or role provided by a 3rd party authorization server, if required. However, at time of writing it is assumed that 
+          # authentication activities are always happening over a client-credentials oauth2 flow.
+          tokenUrl: https://well-known/oauth-authorization-server/token
+          refreshUrl: https://well-known/oauth-authorization-server/refresh
+          scopes:
+            fraihmwork.component.admin: Client may create, read, update, or delete any component regardless of creator.
+            fraihmwork.component.write: Client may create new components, but can only update and delete components they create. Client may read all components regardless of creator.
+            fraihmwork.component.read: Client may read any component that FRAIHMWORK can provide, regardless of creator.

--- a/FraihmworkRulesEngineApi.yaml
+++ b/FraihmworkRulesEngineApi.yaml
@@ -52,6 +52,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RuleTemplate'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
         401:
           description: Not authenticated
           content:
@@ -60,18 +66,6 @@ paths:
                 $ref: '#/components/schemas/Response'
         403:
           description: Forbidden - client is not authorized to read rule templates
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-        400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-        404:
-          description: Not Found
           content:
             application/json:
               schema:
@@ -112,6 +106,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RuleInstance'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
         401:
           description: Not authenticated
           content:
@@ -120,12 +120,6 @@ paths:
                 $ref: '#/components/schemas/Response'
         403:
           description: Forbidden - client is not authorized to read rule instances
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-        400:
-          description: Bad Request
           content:
             application/json:
               schema:
@@ -158,8 +152,20 @@ paths:
             schema:
               $ref: '#/components/schemas/RuleInstance'
       responses:
-        200:
-          description: OK
+        201:
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        208:
+          description: Rule already created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        400:
+          description: Bad request, incoming JSON malformed or not matching template
           content:
             application/json:
               schema:
@@ -172,12 +178,6 @@ paths:
                 $ref: '#/components/schemas/Response'
         403:
           description: Forbidden - client is not authorized to read rule instances
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-        400:
-          description: Bad request, incoming JSON malformed or not matching template
           content:
             application/json:
               schema:
@@ -218,6 +218,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuleInstance'
+        400:
+          description: Bad request, likely due to malformed UUID input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
         401:
           description: Not authenticated
           content:
@@ -226,12 +232,6 @@ paths:
                 $ref: '#/components/schemas/Response'
         403:
           description: Forbidden - client is not authorized to read rule instances
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-        400:
-          description: Bad request, likely due to malformed UUID input
           content:
             application/json:
               schema:
@@ -277,6 +277,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
         401:
           description: Not authenticated
           content:
@@ -285,12 +291,6 @@ paths:
                 $ref: '#/components/schemas/Response'
         403:
           description: Forbidden - client is not authorized to read rule instances
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Response'
-        400:
-          description: Bad Request
           content:
             application/json:
               schema:

--- a/FraihmworkRulesEngineApi.yaml
+++ b/FraihmworkRulesEngineApi.yaml
@@ -375,7 +375,7 @@ components:
         ruleInstanceSchema:
           type: object
           additionalProperties: true
-          description: The JSON schema that is used for the generation of any rule instantiations of this template, as a free form object, since JSON Schemas are JSON
+          description: The JSON schema that is used for the generation of any rule instantiations of this template. Since JSON schemas are JSON, this acts as the root node for a JSON schema declaration so that the API result is human readable, but still usable by consuming services
       required:
         - name
         - amqpExchange

--- a/FraihmworkRulesEngineApi.yaml
+++ b/FraihmworkRulesEngineApi.yaml
@@ -4,7 +4,7 @@ info:
   title: FRAIHMWORK Rules Engine Service API
   description: 'As data moves through FRAIHMWORK, there are many reactions the system must take in order to ensure correct behavior across the ecosystem. This API allows for instantiations of rules to be implemented into the target deployment that allows some of these actions to be automated. This API will be versioned according to SemVer 2.0.0 rules (as described here: https://semver.org/)'
   contact:
-    email: g.dorchies@resilienx.com
+    email: support@resilienx.com
   version: 0.1.0
 externalDocs:
   description: Find out more about Swagger
@@ -375,7 +375,7 @@ components:
         ruleInstanceSchema:
           type: object
           additionalProperties: true
-          description: The JSON schema that is used for the generation of any rule instatiations of this template, as a free form object, since JSON Schemas are JSON
+          description: The JSON schema that is used for the generation of any rule instantiations of this template, as a free form object, since JSON Schemas are JSON
       required:
         - name
         - amqpExchange

--- a/FraihmworkRulesEngineApiChangelist.txt
+++ b/FraihmworkRulesEngineApiChangelist.txt
@@ -1,0 +1,2 @@
+Version 0.1.0:
+Initial version


### PR DESCRIPTION
This PR introduces the new FRES API to allow rule instances to be specified, and rule templates to be retrieved from the FRES.

This review is inspection only, though you can toss the contents into https://editor.swagger.io/ for some automated syntax checking and slightly easier viewing.



Some notes on vision:

The code block below shows how I envision the rule template and instances looking at the end of the day, when looking at the FRES (looking ahead to [FRAIHM-3375](https://resilienx.atlassian.net/browse/FRAIHM-3375)). The JSON schema element is used to define the constants that the DMN file expects, and they are supplied by the declaration of the rule instance. Note that below is meant to convey general idea, may not be syntax correct all the way through.
```
Rule template
{
  "name" : "cascadingComponentDelete",
  "exchange" : "presentation-exchange",
  "routingKey" : "#.delete.#",
  "description": "Deletes a specific component in response to another component being deleted",
  "dmnFile" : <pulled from a component-deletion.dmn file>
  "jsonSchema" : <pulled from some component-deletion.jsonschema file or defined inline>
}

component-deletion.schema
{
  "type": "object",
  "properties": {
    "sourceComponentUuid" : { 
      "type": "string"
    },
    "targetComponentUuid" : { 
      "type": "string"
    },
  }
}

component-deletion.dmn 
<too complex to show here>

Rule Instance definition
{
  "template": "cascadingComponentDelete",
  "description": "Deletes A when B is deleted",
  "rule": {
    "sourceComponentUuid" : "aaaa-bbbb....",
    "targetComponentUuid" : "ffff-eeee....",    
  }
}

```