### PR TITLE
Risk Assessment API Inc 1 Specification Revision

### DIFF
--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -676,7 +676,7 @@ components:
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
           description: The thresholds used for this risk assessment.
-        operation:
+        flightOperation:
           type: object
           description: The flight operation unique identifier and waypoints for which the risk assessment report was generated
           properties:
@@ -698,7 +698,7 @@ components:
       - riskStatistics
       - riskResults
       - riskThresholds
-      - operation
+      - flightOperation
 
   securitySchemes:
     OAuth2:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -392,7 +392,7 @@ components:
           description: The threshold for the number of obstacles within the minimum distance
       required:
       - minimumDistanceMeters
-      - buildingCount
+      - obstacleCount
 
     GroundImpactRiskThresholds:
       type: object
@@ -429,7 +429,7 @@ components:
           description: The threshold for the weighted risk which incorporates satellite count, PDOP, and map tile availability
       required:
       - satelliteCount
-      - positionDilutionOfPrecision
+      - pdop
       - weightedRisk
 
     RiskThresholds:
@@ -535,7 +535,7 @@ components:
               required:
               - obstacleProximity
               - groundImpact
-              - navigation
+              - navigationReliability
             thresholds:
               type: object
               description: A collection of thresholds for determining overall risk level
@@ -608,7 +608,7 @@ components:
 
     RiskAssessment:
       type: object
-      description:
+      description: A risk assessment report including a Flight Go-Ahead Indicator, plus supporting artifacts
       properties:
         flightGoAheadIndicator:
           type: boolean
@@ -676,9 +676,9 @@ components:
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
           description: The thresholds used for this risk assessment.
-        flightOperation:
+        flightOperationSummary:
           type: object
-          description: The flight operation unique identifier and waypoints for which the risk assessment report was generated
+          description: The flight operation unique identifier and waypoints for which the risk assessment report was generated. For the full flight operation, perform a GET on the /risk/v0/operation/{uuid} endpoint
           properties:
             uuid:
               type: string

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -117,7 +117,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         404:
-          description: Not Found - flight operation with specified unique identifier not found
+          description: Not Found - flight operation with specified unique identifier does not exist
           content:
             application/json:
               schema:
@@ -177,7 +177,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         404:
-          description: Not Found - flight operation with specified unique identifier not found
+          description: Not Found - flight operation with specified unique identifier does not exist
           content:
             application/json:
               schema:
@@ -239,7 +239,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         404:
-          description: Not Found - flight operation with specified unique identifier not found
+          description: Not Found - flight operation with specified unique identifier does not exist
           content:
             application/json:
               schema:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -281,7 +281,7 @@ components:
         uuid:
           type: string
           format: uuid
-          description: The unique identifier of the vehicle; Assigned by the caller
+          description: The unique identifier of the vehicle. Assigned by the caller
         type:
           type: string
           enum: ['ROTOR', 'FIXED_WING', 'FIXED_WING_WITH_PARACHUTE']
@@ -309,6 +309,7 @@ components:
           format: double
           minimum: 0.0
           description: The default speed of the vehicle in meters per second. It may be overridden by a speed value for a waypoint
+      additionalProperties: true
       required:
       - uuid
       - type
@@ -346,6 +347,7 @@ components:
           format: double
           minimum: 0.0
           description: The speed of the vehicle as it travels from this waypoint to the next waypoint in meters per second. If not provided, the default speed of the vehicle may be used
+      additionalProperties: true
       required:
       - latitude
       - longitude
@@ -371,6 +373,7 @@ components:
           format: double
           minimum: 0.0
           description: The speed of the wind in meters per second
+      additionalProperties: true
       required:
       - altitudeMetersMsl
       - directionDegrees
@@ -390,6 +393,7 @@ components:
           format: double
           minimum: 0
           description: The threshold for the number of obstacles within the minimum distance
+      additionalProperties: true
       required:
       - minimumDistanceMeters
       - obstacleCount
@@ -404,6 +408,7 @@ components:
           minimum: 0.0
           maximum: 1.0
           description: The threshold for the probability of casualty for ground impact impact
+      additionalProperties: true
       required:
       - probabilityOfCasualty
 
@@ -427,6 +432,7 @@ components:
           minimum: 0.0
           maximum: 1.0
           description: The threshold for the weighted risk which incorporates satellite count, PDOP, and map tile availability
+      additionalProperties: true
       required:
       - satelliteCount
       - pdop
@@ -446,6 +452,7 @@ components:
             highThresholds:
               $ref: '#/components/schemas/ObstacleProximityRiskThresholds'
               description: A collection of thresholds for setting obstacle proximity risk level to HIGH
+          additionalProperties: true
           required:
           - mediumThresholds
           - highThresholds
@@ -459,6 +466,7 @@ components:
             highThresholds:
               $ref: '#/components/schemas/GroundImpactRiskThresholds'
               description: A collection of thresholds for setting ground impact risk level to HIGH
+          additionalProperties: true
           required:
           - mediumThresholds
           - highThresholds
@@ -494,6 +502,7 @@ components:
                   minimum: 0.0
                   maximum: 1.0
                   description: The weighting of map tile availability risk
+              additionalProperties: true
               required:
               - satelliteCount
               - pdop
@@ -501,6 +510,7 @@ components:
             forceHighRiskIfMapTileUnavailable:
               type: boolean
               description: The toggle for forcing navigation reliability risk level to HIGH if map tile is unavailable
+          additionalProperties: true
           required:
           - mediumThresholds
           - highThresholds
@@ -532,6 +542,7 @@ components:
                   minimum: 0.0
                   maximum: 1.0
                   description: The weighting of navigation reliability risk
+              additionalProperties: true
               required:
               - obstacleProximity
               - groundImpact
@@ -561,6 +572,7 @@ components:
               minimum: 0.0
               maximum: 1.0
               description: The threshold for the percentage of waypoints with an overall HIGH risk for setting Flight Go-Ahead Indicator to FALSE
+      additionalProperties: true
 
     FlightOperation:
       type: object
@@ -569,7 +581,7 @@ components:
         uuid:
           type: string
           format: uuid
-          description: The unique identifier of the flight operation; Optionally assigned by the service
+          description: The unique identifier of the flight operation. Optionally assigned by the service
         startTime:
           type: string
           format: date-time
@@ -578,38 +590,64 @@ components:
           $ref: '#/components/schemas/Vehicle'
         waypoints:
           type: array
+          description: An ordered list of waypoints making up the flight operation
+          minItems: 2
           items:
             $ref: '#/components/schemas/Waypoint'
-          minItems: 2
-          description: An ordered list of waypoints making up the flight operation
         weatherServiceEnabled:
           type: boolean
           description: The toggle for enabling use of any available dynamic weather service data. If enabled, the wind profile is ignored
         windProfile:
           type: array
+          description: A list of wind measurements making up a wind profile
           items:
             $ref: '#/components/schemas/WindMeasurement'
-          description: A list of wind measurements making up a wind profile
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
           description: The risk thresholds provided to override pre-configured thresholds.
+      additionalProperties: true
       required:
       - startTime
       - vehicle
       - waypoints
 
+    RiskLevel:
+      type: string
+      enum: ['LOW', 'MEDIUM', 'HIGH']
+      description: The levels of risk
+
     RiskResults:
       type: object
-      description: The mapping of waypoint number to risk level
-      additionalProperties:
-        type: string
-        enum: ['LOW', 'MEDIUM', 'HIGH']
-        description: The level of the risk
+      description: The pairing of a waypoint from the flight operation and associated risk levels
+      properties:
+        waypoint:
+          $ref: '#/components/schemas/Waypoint'
+          description: A waypoint from the flight operation
+        overallRiskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          description: The overall risk level for the given waypoints
+        obstacleProximityRiskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          description: The obstacle proximity risk level for the given waypoints
+        groundImpactRiskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          description: The ground impact risk level for the given waypoints
+        navigationReliabilityRiskLevel:
+          $ref: '#/components/schemas/RiskLevel'
+          description: The navigation reliability risk level for the given waypoints
+      additionalProperties: true
+      required:
+      - waypoint
+      - overallRiskLevel
 
     RiskAssessment:
       type: object
       description: A risk assessment report including a Flight Go-Ahead Indicator, plus supporting artifacts
       properties:
+        flightOperationUuid:
+          type: string
+          format: uuid
+          description: The unique identifier of the flight operation for which the risk assessment report was generated
         flightGoAheadIndicator:
           type: boolean
           description: The go-ahead indication for the flight operation based on the risk assessment with TRUE meaning go-ahead and FALSE meaning do not go-ahead
@@ -637,68 +675,46 @@ components:
               type: integer
               format: int32
               description: The number of waypoints receiving a LOW risk
-            obstacleProximityRiskWaypointPercentage:
+            obstacleProximityRiskyWaypointPercentage:
               type: number
               format: double
               minimum: 0.0
               maximum: 100.0
               description: The percentage of waypoints receiving a HIGH or MEDIUM obstacle proximity risk
-            groundImpactRiskWaypointPercentage:
+            groundImpactRiskyWaypointPercentage:
               type: number
               format: double
               minimum: 0.0
               maximum: 100.0
               description: The percentage of waypoints receiving a HIGH or MEDIUM ground impact risk
-            navigationReliabilityRiskWaypointPercentage:
+            navigationReliabilityRiskyWaypointPercentage:
               type: number
               format: double
               minimum: 0.0
               maximum: 100.0
               description: The percentage of waypoints receiving a HIGH or MEDIUM navigation reliability risk
           additionalProperties: true
+          required:
+          - overallWeightedRisk
+          - totalWaypointCount
+          - highRiskWaypointCount
+          - mediumRiskWaypointCount
+          - lowRiskWaypointCount
         riskResults:
-          type: object
-          description: The risk assessment results used to determine the risk levels
-          properties:
-            overallRisk:
-              $ref: '#/components/schemas/RiskResults'
-              description: The mapping of waypoint number to overall risk level
-            obstacleProximityRisk:
-              $ref: '#/components/schemas/RiskResults'
-              description: The mapping of waypoint number to obstacle proximity risk level
-            groundImpactRisk:
-              $ref: '#/components/schemas/RiskResults'
-              description: The mapping of waypoint number to ground impact risk level
-            navigationReliabilityRisk:
-              $ref: '#/components/schemas/RiskResults'
-              description: The mapping of waypoint number to navigation reliability risk level
-          additionalProperties: true
+          type: array
+          description: An ordered list of waypoints making up the flight operation and their associated risk levels
+          items:
+            $ref: '#/components/schemas/RiskResults'
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
           description: The thresholds used for this risk assessment.
-        flightOperationSummary:
-          type: object
-          description: The flight operation unique identifier and waypoints for which the risk assessment report was generated. For the full flight operation, perform a GET on the /risk/v0/operation/{uuid} endpoint
-          properties:
-            uuid:
-              type: string
-              format: uuid
-              description: The unique identifier of the flight operation
-            waypoints:
-              type: object
-              additionalProperties:
-                $ref: '#/components/schemas/Waypoint'
-              description: The mapping of waypoint number to waypoint definition 
-          required:
-          - uuid
-          - waypoints
       additionalProperties: true
       required:
+      - flightOperationUuid
       - flightGoAheadIndicator
       - riskStatistics
       - riskResults
       - riskThresholds
-      - flightOperation
 
   securitySchemes:
     OAuth2:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -5,7 +5,7 @@ info:
   description: 'This API allows for generating risk assessment reports against flight operations. This API will be versioned according to SemVer 2.0.0 rules (as described here: https://semver.org/).'
   contact:
     email: support@resilienx.com
-  version: 0.1.0
+  version: 0.2.0
 externalDocs:
   description: Find out more about Swagger
   url: http://swagger.io
@@ -248,9 +248,147 @@ components:
       - directionDegrees
       - speedMetersPerSecond
 
+    ThreatRiskThresholds:
+      type: object
+      description: A collection of thresholds for setting threat risk level
+      properties:
+        distanceMeters:
+          type: number
+          format: double
+          minimum: 0.0
+          description: The threshold for the minimum distance to any threat in meters
+        buildingCount:
+          type: number
+          format: double
+          minimum: 0
+          description: The threshold for the number of building threats
+      required:
+      - distanceMeters
+      - buildingCount
+
+    GroundRiskThresholds:
+      type: object
+      description: A collection of thresholds for setting ground risk level
+      properties:
+        probabilityOfCasualty:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          description: The threshold for the probability of casualty for ground impact in decimal percentage [0.0, 1.0]
+      required:
+      - probabilityOfCasualty
+
+    NavigationRiskThresholds:
+      type: object
+      description: A collection of thresholds for setting navigation risk level
+      properties:
+        satelliteCount:
+          type: integer
+          format: int32
+          minimum: 0
+          description: The threshold for the number of visible satellites
+        positionDilutionOfPrecision:
+          type: number
+          format: double
+          minimum: 0.0
+          description: The threshold for the position dilution of precision (PDOP) indicating the strength of the satellite constellation for determining position
+      required:
+      - satelliteCount
+      - positionDilutionOfPrecision
+
+    RiskThresholds:
+      type: object
+      description: A collection of thresholds for determining various risk levels
+      properties:
+        threatRisk:
+          type: object
+          description: A collection of thresholds for determining threat risk level
+          properties:
+            mediumThresholds:
+              $ref: '#/components/schemas/ThreatRiskThresholds'
+              description: A collection of thresholds for setting threat risk level to MEDIUM
+            highThresholds:
+              $ref: '#/components/schemas/ThreatRiskThresholds'
+              description: A collection of thresholds for setting threat risk level to HIGH
+          required:
+          - mediumThresholds
+          - highThresholds
+        groundRisk:
+          type: object
+          description: A collection of thresholds for determining ground risk level
+          properties:
+            mediumThresholds:
+              $ref: '#/components/schemas/GroundRiskThresholds'
+              description: A collection of thresholds for setting ground risk level to MEDIUM
+            highThresholds:
+              $ref: '#/components/schemas/GroundRiskThresholds'
+              description: A collection of thresholds for setting ground risk level to HIGH
+          required:
+          - mediumThresholds
+          - highThresholds
+        navigationRisk:
+          type: object
+          description: A collection of thresholds for determining navigation risk level
+          properties:
+            mediumThresholds:
+              $ref: '#/components/schemas/NavigationRiskThresholds'
+              description: A collection of thresholds for setting navigation risk level to MEDIUM
+            highThresholds:
+              $ref: '#/components/schemas/NavigationRiskThresholds'
+              description: A collection of thresholds for setting navigation risk level to HIGH
+          required:
+          - mediumThresholds
+          - highThresholds
+        overallRisk:
+          type: object
+          description: A collection of thresholds for determining overall risk level
+          properties:
+            weights:
+              type: object
+              description: The weighting to apply to each risk level when determining the overall risk
+              properties:
+                threat:
+                  type: number
+                  format: double
+                  description: The weighting of threat risk when determining the overall risk
+                ground:
+                  type: number
+                  format: double
+                  description: The weighting of ground risk when determining the overall risk
+                navigation:
+                  type: number
+                  format: double
+                  description: The weighting of navigation risk when determining the overall risk
+              required:
+              - threat
+              - ground
+              - navigation
+            thresholds:
+              type: object
+              description: A collection of thresholds for determining overall risk level
+              properties:
+                medium:
+                  type: number
+                  format: double
+                  description: The threshold for setting overall risk level to MEDIUM
+                high:
+                  type: number
+                  format: double
+                  description: The threshold for setting overall risk level to HIGH
+              required:
+              - medium
+              - high
+            noGoHighRiskWaypointPercentage:
+              type: number
+              format: double
+              minimum: 0.0
+              maximum: 1.0
+              description: The threshold for the percentage of waypoints with an overall HIGH risk for setting go/no-go to NO-GO in decimal percentage [0.0, 1.0]
+
     FlightOperation:
       type: object
-      description: A collection of ordered waypoints to be flown by a vehicle, plus metadata to aid in risk assessment
+      description: A collection of ordered waypoints to be flown by a vehicle, plus metadata and thresholds to aid in risk assessment
       properties:
         uuid:
           type: string
@@ -276,21 +414,120 @@ components:
           items:
             $ref: '#/components/schemas/WindMeasurement'
           description: A list of wind measurements making up a wind profile
+        riskThresholds:
+          $ref: '#/components/schemas/RiskThresholds'
+          description: The thresholds provided to override pre-configured thresholds.
       required:
       - startTime
       - vehicle
       - waypoints
 
+    RiskResults:
+      type: object
+      description: The mapping of waypoint number to risk level
+      additionalProperties:
+        type: string
+        enum: ['LOW', 'MEDIUM', 'HIGH']
+        description: The level of the risk
+
     RiskAssessment:
       type: object
+      description:
       properties:
         operation:
           $ref: '#/components/schemas/FlightOperation'
           description: The flight operation for which the risk assessment report was generated
         assessment:
           type: object
+          properties:
+            flightGoAheadIndicator:
+              type: boolean
+              description: The GO (true) / NO-GO (false) indication for the flight operation based on the risk assessment
+            overallWeightedRisk:
+              type: number
+              format: double
+              description: The weighted overall risk level
+            riskLevels:
+              type: object
+              description: The various risk levels
+              properties:
+                overallRisk:
+                  type: number
+                  format: double
+                  description: The overall risk level
+                threatRisk:
+                  type: number
+                  format: double
+                  description: The threat risk level
+                groundRisk:
+                  type: number
+                  format: double
+                  description: The ground risk level
+                navigationRisk:
+                  type: number
+                  format: double
+                  description: The navigation risk level
+              additionalProperties: true
+            riskResults:
+              type: object
+              description: The risk assessment results used to determine the risk levels
+              properties:
+                overallRisk:
+                  $ref: '#/components/schemas/RiskResults'
+                  description: The mapping of waypoint number to overall risk level
+                threatRisk:
+                  $ref: '#/components/schemas/RiskResults'
+                  description: The mapping of waypoint number to threat risk level
+                groundRisk:
+                  $ref: '#/components/schemas/RiskResults'
+                  description: The mapping of waypoint number to ground risk level
+                navigationRisk:
+                  $ref: '#/components/schemas/RiskResults'
+                  description: The mapping of waypoint number to navigation risk level
+              additionalProperties: true
+            riskStatistics:
+              type: object
+              description: A collection of statistics for the risk assessment
+              properties:
+                totalWaypointCount:
+                  type: integer
+                  format: int32
+                  description: The total number of waypoints assessed for risk
+                highRiskWaypointCount:
+                  type: integer
+                  format: int32
+                  description: The number of waypoints receiving a HIGH risk score
+                mediumRiskWaypointCount:
+                  type: integer
+                  format: int32
+                  description: The number of waypoints receiving a MEDIUM risk score
+                lowRiskWaypointCount:
+                  type: integer
+                  format: int32
+                  description: The number of waypoints receiving a LOW risk score
+                threatRiskWaypointPercentage:
+                  type: number
+                  format: double
+                  minimum: 0.0
+                  maximum: 100.0
+                  description: The percentage of waypoints receiving a HIGH or MEDIUM threat risk score
+                groundRiskWaypointPercentage:
+                  type: number
+                  format: double
+                  minimum: 0.0
+                  maximum: 100.0
+                  description: The percentage of waypoints receiving a HIGH or MEDIUM ground risk score
+                navigationRiskWaypointPercentage:
+                  type: number
+                  format: double
+                  minimum: 0.0
+                  maximum: 100.0
+                  description: The percentage of waypoints receiving a HIGH or MEDIUM navigation risk score
+              additionalProperties: true
+            riskThresholds:
+              $ref: '#/components/schemas/RiskThresholds'
+              description: The thresholds used for this risk assessment.
           additionalProperties: true
-          description: The freeform risk assessment report
       required:
       - operation
       - assessment

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -63,7 +63,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         409:
-          description: Conflict - flight operation with specified unique identifier already exists
+          description: Conflict - flight operation with specified unique identifier exists
           content:
             application/json:
               schema:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -23,7 +23,7 @@ paths:
       tags:
       - Risk Assessment
       summary: Post a flight operation for risk assessment
-      operationId: postOperation
+      operationId: postFlightOperation
       requestBody:
         description: JSON description of the flight operation
         required: true
@@ -39,13 +39,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         400:
-          description: Bad request, incoming JSON malformed
+          description: Bad Request - client error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
         401:
-          description: Not authenticated
+          description: Not Authenticated
           content:
             application/json:
               schema:
@@ -57,13 +57,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         406:
-          description: Not acceptable - only responds in application/json format
+          description: Not Acceptable - only responds in application/json format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        409:
+          description: Conflict - flight operation with specified unique identifier already exists
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
         500:
-          description: Server error
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -71,12 +77,72 @@ paths:
       security:
       - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
 
+  /risk/v0/operation/{uuid}:
+    get:
+      tags:
+      - Risk Assessment
+      summary: Retrieve a flight operation for risk assessment
+      operationId: getFlightOperationByUuid
+      parameters:
+      - name: uuid
+        in: path
+        description: The unique identifier of the flight operation
+        schema:
+          type: string
+          format: uuid
+        required: true
+      responses:
+        200:
+          description: OK - flight operation found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/FlightOperation'
+        400:
+          description: Bad Request - client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Not Authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to post flight operations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Not Found - flight operation with specified unique identifier not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not Acceptable - only responds in application/json format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
+
   /risk/v0/assessment:
     get:
       tags:
       - Risk Assessment
       summary: Request risk assessment for a specific flight operation
-      operationId: getAssessment
+      operationId: getRiskAssessment
       parameters:
       - name: operationUuid
         in: query
@@ -87,13 +153,13 @@ paths:
         required: true
       responses:
         200:
-          description: Successful risk assessment
+          description: OK - successful risk assessment
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RiskAssessment'
         202:
-          description: Accepted - Risk assessment in progress
+          description: Accepted - risk assessment in progress
           content:
             application/json:
               schema:
@@ -111,19 +177,81 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         404:
-          description: Flight operation with specified UUID not found
+          description: Not Found - flight operation with specified unique identifier not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
         406:
-          description: Not acceptable - only responds in application/json format
+          description: Not Acceptable - only responds in application/json format
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Response'
         500:
-          description: Server error
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
+        
+  /risk/v0/assessment/rawResults:
+    get:
+      tags:
+      - Risk Assessment
+      summary: Request risk assessment's raw results for a specific flight operation
+      operationId: getRiskAssessmentRawResults
+      parameters:
+      - name: operationUuid
+        in: query
+        description: The unique identifier of the flight operation for which to retrieve the risk assessment's raw results
+        schema:
+          type: string
+          format: uuid
+        required: true
+      responses:
+        200:
+          description: OK - successful risk assessment
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                description: The freeform risk assessment raw results
+        202:
+          description: Accepted - risk assessment in progress
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to query risk assessment reports
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Not Found - flight operation with specified unique identifier not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not Acceptable - only responds in application/json format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -248,40 +376,40 @@ components:
       - directionDegrees
       - speedMetersPerSecond
 
-    ThreatRiskThresholds:
+    ObstacleProximityRiskThresholds:
       type: object
-      description: A collection of thresholds for setting threat risk level
+      description: A collection of thresholds for setting obstacle proximity risk level
       properties:
         minimumDistanceMeters:
           type: number
           format: double
           minimum: 0.0
-          description: The threshold for the minimum distance to any threat in meters
-        buildingCount:
+          description: The threshold for the minimum distance to any obstacle in meters
+        obstacleCount:
           type: number
           format: double
           minimum: 0
-          description: The threshold for the number of building threats
+          description: The threshold for the number of obstacles within the minimum distance
       required:
       - minimumDistanceMeters
       - buildingCount
 
-    GroundRiskThresholds:
+    GroundImpactRiskThresholds:
       type: object
-      description: A collection of thresholds for setting ground risk level
+      description: A collection of thresholds for setting ground impact risk level
       properties:
         probabilityOfCasualty:
           type: number
           format: double
           minimum: 0.0
           maximum: 1.0
-          description: The threshold for the probability of casualty for ground impact in decimal percentage [0.0, 1.0]
+          description: The threshold for the probability of casualty for ground impact impact
       required:
       - probabilityOfCasualty
 
-    NavigationRiskThresholds:
+    NavigationReliabilityRiskThresholds:
       type: object
-      description: A collection of thresholds for setting navigation risk level
+      description: A collection of thresholds for setting navigation reliability risk level
       properties:
         satelliteCount:
           type: integer
@@ -306,73 +434,73 @@ components:
 
     RiskThresholds:
       type: object
-      description: A collection of thresholds for determining various risk levels
+      description: A collection of thresholds for determining individual risk levels and overall risk level
       properties:
-        threatRisk:
+        obstacleProximityRisk:
           type: object
-          description: A collection of thresholds for determining threat risk level
+          description: A collection of thresholds for determining the obstacle proximity risk level based on the distance and number of obstacles like buildings
           properties:
             mediumThresholds:
-              $ref: '#/components/schemas/ThreatRiskThresholds'
-              description: A collection of thresholds for setting threat risk level to MEDIUM
+              $ref: '#/components/schemas/ObstacleProximityRiskThresholds'
+              description: A collection of thresholds for setting obstacle proximity risk level to MEDIUM
             highThresholds:
-              $ref: '#/components/schemas/ThreatRiskThresholds'
-              description: A collection of thresholds for setting threat risk level to HIGH
+              $ref: '#/components/schemas/ObstacleProximityRiskThresholds'
+              description: A collection of thresholds for setting obstacle proximity risk level to HIGH
           required:
           - mediumThresholds
           - highThresholds
-        groundRisk:
+        groundImpactRisk:
           type: object
-          description: A collection of thresholds for determining ground risk level
+          description: A collection of thresholds for determining ground impact risk level based on the probability of casualty
           properties:
             mediumThresholds:
-              $ref: '#/components/schemas/GroundRiskThresholds'
-              description: A collection of thresholds for setting ground risk level to MEDIUM
+              $ref: '#/components/schemas/GroundImpactRiskThresholds'
+              description: A collection of thresholds for setting ground impact risk level to MEDIUM
             highThresholds:
-              $ref: '#/components/schemas/GroundRiskThresholds'
-              description: A collection of thresholds for setting ground risk level to HIGH
+              $ref: '#/components/schemas/GroundImpactRiskThresholds'
+              description: A collection of thresholds for setting ground impact risk level to HIGH
           required:
           - mediumThresholds
           - highThresholds
-        navigationRisk:
+        navigationReliabilityRisk:
           type: object
-          description: A collection of thresholds for determining navigation risk level
+          description: A collection of thresholds for determining navigation reliability risk level
           properties:
             mediumThresholds:
-              $ref: '#/components/schemas/NavigationRiskThresholds'
-              description: A collection of thresholds for setting navigation risk level to MEDIUM
+              $ref: '#/components/schemas/NavigationReliabilityRiskThresholds'
+              description: A collection of thresholds for setting navigation reliability risk level to MEDIUM
             highThresholds:
-              $ref: '#/components/schemas/NavigationRiskThresholds'
-              description: A collection of thresholds for setting navigation risk level to HIGH
+              $ref: '#/components/schemas/NavigationReliabilityRiskThresholds'
+              description: A collection of thresholds for setting navigation reliability risk level to HIGH
             weights:
               type: object
-              description: The weighting to apply to each risk level when determining the navigation risk. The weights should sum to 1.0
+              description: The weighting to apply to each risk level when determining the navigation reliability risk. The weights should sum to 1.0
               properties:
                 satelliteCount:
                   type: number
                   format: double
                   minimum: 0.0
                   maximum: 1.0
-                  description: The weighting of satellite count risk in decimal percentage [0.0, 1.0]
+                  description: The weighting of satellite count risk
                 pdop:
                   type: number
                   format: double
                   minimum: 0.0
                   maximum: 1.0
-                  description: The weighting of PDOP risk in decimal percentage [0.0, 1.0]
+                  description: The weighting of PDOP risk
                 mapTileAvailability:
                   type: number
                   format: double
                   minimum: 0.0
                   maximum: 1.0
-                  description: The weighting of map tile availability risk in decimal percentage [0.0, 1.0]
+                  description: The weighting of map tile availability risk
               required:
               - satelliteCount
               - pdop
               - mapTileAvailability
             forceHighRiskIfMapTileUnavailable:
               type: boolean
-              description: The toggle for forcing navigation risk level to HIGH if map tile is unavailable
+              description: The toggle for forcing navigation reliability risk level to HIGH if map tile is unavailable
           required:
           - mediumThresholds
           - highThresholds
@@ -380,33 +508,33 @@ components:
           - forceHighRiskIfMapTileUnavailable
         overallRisk:
           type: object
-          description: A collection of thresholds for determining overall risk level
+          description: A collection of thresholds for determining overall risk level based on a weighting of the individual risk levels
           properties:
             weights:
               type: object
               description: The weighting to apply to each risk level when determining the overall risk. The weights should sum to 1.0
               properties:
-                threat:
+                obstacleProximity:
                   type: number
                   format: double
                   minimum: 0.0
                   maximum: 1.0
-                  description: The weighting of threat risk in decimal percentage [0.0, 1.0]
-                ground:
+                  description: The weighting of obstacle proximity risk
+                groundImpact:
                   type: number
                   format: double
                   minimum: 0.0
                   maximum: 1.0
-                  description: The weighting of ground risk in decimal percentage [0.0, 1.0]
-                navigation:
+                  description: The weighting of ground impact risk
+                navigationReliability:
                   type: number
                   format: double
                   minimum: 0.0
                   maximum: 1.0
-                  description: The weighting of navigation risk in decimal percentage [0.0, 1.0]
+                  description: The weighting of navigation reliability risk
               required:
-              - threat
-              - ground
+              - obstacleProximity
+              - groundImpact
               - navigation
             thresholds:
               type: object
@@ -432,7 +560,7 @@ components:
               format: double
               minimum: 0.0
               maximum: 1.0
-              description: The threshold for the percentage of waypoints with an overall HIGH risk for setting Flight Go-Ahead Indicator to FALSE in decimal percentage [0.0, 1.0]
+              description: The threshold for the percentage of waypoints with an overall HIGH risk for setting Flight Go-Ahead Indicator to FALSE
 
     FlightOperation:
       type: object
@@ -464,7 +592,7 @@ components:
           description: A list of wind measurements making up a wind profile
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
-          description: The thresholds provided to override pre-configured thresholds.
+          description: The risk thresholds provided to override pre-configured thresholds.
       required:
       - startTime
       - vehicle
@@ -482,103 +610,95 @@ components:
       type: object
       description:
       properties:
-        operation:
-          $ref: '#/components/schemas/FlightOperation'
-          description: The flight operation for which the risk assessment report was generated
-        assessment:
+        flightGoAheadIndicator:
+          type: boolean
+          description: The go-ahead indication for the flight operation based on the risk assessment with TRUE meaning go-ahead and FALSE meaning do not go-ahead
+        riskStatistics:
           type: object
+          description: A collection of statistics for the risk assessment
           properties:
-            flightGoAheadIndicator:
-              type: boolean
-              description: The go-ahead indication for the flight operation based on the risk assessment
             overallWeightedRisk:
               type: number
               format: double
               description: The weighted overall risk level
-            riskLevels:
-              type: object
-              description: The various risk levels
-              properties:
-                overallRisk:
-                  type: number
-                  format: double
-                  description: The overall risk level
-                threatRisk:
-                  type: number
-                  format: double
-                  description: The threat risk level
-                groundRisk:
-                  type: number
-                  format: double
-                  description: The ground risk level
-                navigationRisk:
-                  type: number
-                  format: double
-                  description: The navigation risk level
-              additionalProperties: true
-            riskResults:
-              type: object
-              description: The risk assessment results used to determine the risk levels
-              properties:
-                overallRisk:
-                  $ref: '#/components/schemas/RiskResults'
-                  description: The mapping of waypoint number to overall risk level
-                threatRisk:
-                  $ref: '#/components/schemas/RiskResults'
-                  description: The mapping of waypoint number to threat risk level
-                groundRisk:
-                  $ref: '#/components/schemas/RiskResults'
-                  description: The mapping of waypoint number to ground risk level
-                navigationRisk:
-                  $ref: '#/components/schemas/RiskResults'
-                  description: The mapping of waypoint number to navigation risk level
-              additionalProperties: true
-            riskStatistics:
-              type: object
-              description: A collection of statistics for the risk assessment
-              properties:
-                totalWaypointCount:
-                  type: integer
-                  format: int32
-                  description: The total number of waypoints assessed for risk
-                highRiskWaypointCount:
-                  type: integer
-                  format: int32
-                  description: The number of waypoints receiving a HIGH risk score
-                mediumRiskWaypointCount:
-                  type: integer
-                  format: int32
-                  description: The number of waypoints receiving a MEDIUM risk score
-                lowRiskWaypointCount:
-                  type: integer
-                  format: int32
-                  description: The number of waypoints receiving a LOW risk score
-                threatRiskWaypointPercentage:
-                  type: number
-                  format: double
-                  minimum: 0.0
-                  maximum: 100.0
-                  description: The percentage of waypoints receiving a HIGH or MEDIUM threat risk score
-                groundRiskWaypointPercentage:
-                  type: number
-                  format: double
-                  minimum: 0.0
-                  maximum: 100.0
-                  description: The percentage of waypoints receiving a HIGH or MEDIUM ground risk score
-                navigationRiskWaypointPercentage:
-                  type: number
-                  format: double
-                  minimum: 0.0
-                  maximum: 100.0
-                  description: The percentage of waypoints receiving a HIGH or MEDIUM navigation risk score
-              additionalProperties: true
-            riskThresholds:
-              $ref: '#/components/schemas/RiskThresholds'
-              description: The thresholds used for this risk assessment.
+            totalWaypointCount:
+              type: integer
+              format: int32
+              description: The total number of waypoints assessed for risk
+            highRiskWaypointCount:
+              type: integer
+              format: int32
+              description: The number of waypoints receiving a HIGH risk
+            mediumRiskWaypointCount:
+              type: integer
+              format: int32
+              description: The number of waypoints receiving a MEDIUM risk
+            lowRiskWaypointCount:
+              type: integer
+              format: int32
+              description: The number of waypoints receiving a LOW risk
+            obstacleProximityRiskWaypointPercentage:
+              type: number
+              format: double
+              minimum: 0.0
+              maximum: 100.0
+              description: The percentage of waypoints receiving a HIGH or MEDIUM obstacle proximity risk
+            groundImpactRiskWaypointPercentage:
+              type: number
+              format: double
+              minimum: 0.0
+              maximum: 100.0
+              description: The percentage of waypoints receiving a HIGH or MEDIUM ground impact risk
+            navigationReliabilityRiskWaypointPercentage:
+              type: number
+              format: double
+              minimum: 0.0
+              maximum: 100.0
+              description: The percentage of waypoints receiving a HIGH or MEDIUM navigation reliability risk
           additionalProperties: true
+        riskResults:
+          type: object
+          description: The risk assessment results used to determine the risk levels
+          properties:
+            overallRisk:
+              $ref: '#/components/schemas/RiskResults'
+              description: The mapping of waypoint number to overall risk level
+            obstacleProximityRisk:
+              $ref: '#/components/schemas/RiskResults'
+              description: The mapping of waypoint number to obstacle proximity risk level
+            groundImpactRisk:
+              $ref: '#/components/schemas/RiskResults'
+              description: The mapping of waypoint number to ground impact risk level
+            navigationReliabilityRisk:
+              $ref: '#/components/schemas/RiskResults'
+              description: The mapping of waypoint number to navigation reliability risk level
+          additionalProperties: true
+        riskThresholds:
+          $ref: '#/components/schemas/RiskThresholds'
+          description: The thresholds used for this risk assessment.
+        operation:
+          type: object
+          description: The flight operation unique identifier and waypoints for which the risk assessment report was generated
+          properties:
+            uuid:
+              type: string
+              format: uuid
+              description: The unique identifier of the flight operation
+            waypoints:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/Waypoint'
+              description: The mapping of waypoint number to waypoint definition 
+          required:
+          - uuid
+          - waypoints
+      additionalProperties: true
       required:
+      - flightGoAheadIndicator
+      - riskStatistics
+      - riskResults
+      - riskThresholds
       - operation
-      - assessment
 
   securitySchemes:
     OAuth2:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -252,7 +252,7 @@ components:
       type: object
       description: A collection of thresholds for setting threat risk level
       properties:
-        distanceMeters:
+        minimumDistanceMeters:
           type: number
           format: double
           minimum: 0.0
@@ -263,7 +263,7 @@ components:
           minimum: 0
           description: The threshold for the number of building threats
       required:
-      - distanceMeters
+      - minimumDistanceMeters
       - buildingCount
 
     GroundRiskThresholds:
@@ -288,14 +288,21 @@ components:
           format: int32
           minimum: 0
           description: The threshold for the number of visible satellites
-        positionDilutionOfPrecision:
+        pdop:
           type: number
           format: double
           minimum: 0.0
           description: The threshold for the position dilution of precision (PDOP) indicating the strength of the satellite constellation for determining position
+        weightedRisk:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 1.0
+          description: The threshold for the weighted risk which incorporates satellite count, PDOP, and map tile availability
       required:
       - satelliteCount
       - positionDilutionOfPrecision
+      - weightedRisk
 
     RiskThresholds:
       type: object
@@ -337,29 +344,66 @@ components:
             highThresholds:
               $ref: '#/components/schemas/NavigationRiskThresholds'
               description: A collection of thresholds for setting navigation risk level to HIGH
+            weights:
+              type: object
+              description: The weighting to apply to each risk level when determining the navigation risk. The weights should sum to 1.0
+              properties:
+                satelliteCount:
+                  type: number
+                  format: double
+                  minimum: 0.0
+                  maximum: 1.0
+                  description: The weighting of satellite count risk in decimal percentage [0.0, 1.0]
+                pdop:
+                  type: number
+                  format: double
+                  minimum: 0.0
+                  maximum: 1.0
+                  description: The weighting of PDOP risk in decimal percentage [0.0, 1.0]
+                mapTileAvailability:
+                  type: number
+                  format: double
+                  minimum: 0.0
+                  maximum: 1.0
+                  description: The weighting of map tile availability risk in decimal percentage [0.0, 1.0]
+              required:
+              - satelliteCount
+              - pdop
+              - mapTileAvailability
+            forceHighRiskIfMapTileUnavailable:
+              type: boolean
+              description: The toggle for forcing navigation risk level to HIGH if map tile is unavailable
           required:
           - mediumThresholds
           - highThresholds
+          - weights
+          - forceHighRiskIfMapTileUnavailable
         overallRisk:
           type: object
           description: A collection of thresholds for determining overall risk level
           properties:
             weights:
               type: object
-              description: The weighting to apply to each risk level when determining the overall risk
+              description: The weighting to apply to each risk level when determining the overall risk. The weights should sum to 1.0
               properties:
                 threat:
                   type: number
                   format: double
-                  description: The weighting of threat risk when determining the overall risk
+                  minimum: 0.0
+                  maximum: 1.0
+                  description: The weighting of threat risk in decimal percentage [0.0, 1.0]
                 ground:
                   type: number
                   format: double
-                  description: The weighting of ground risk when determining the overall risk
+                  minimum: 0.0
+                  maximum: 1.0
+                  description: The weighting of ground risk in decimal percentage [0.0, 1.0]
                 navigation:
                   type: number
                   format: double
-                  description: The weighting of navigation risk when determining the overall risk
+                  minimum: 0.0
+                  maximum: 1.0
+                  description: The weighting of navigation risk in decimal percentage [0.0, 1.0]
               required:
               - threat
               - ground
@@ -371,10 +415,14 @@ components:
                 medium:
                   type: number
                   format: double
+                  minimum: 0.0
+                  maximum: 1.0
                   description: The threshold for setting overall risk level to MEDIUM
                 high:
                   type: number
                   format: double
+                  minimum: 0.0
+                  maximum: 1.0
                   description: The threshold for setting overall risk level to HIGH
               required:
               - medium
@@ -384,7 +432,7 @@ components:
               format: double
               minimum: 0.0
               maximum: 1.0
-              description: The threshold for the percentage of waypoints with an overall HIGH risk for setting go/no-go to NO-GO in decimal percentage [0.0, 1.0]
+              description: The threshold for the percentage of waypoints with an overall HIGH risk for setting Flight Go-Ahead Indicator to FALSE in decimal percentage [0.0, 1.0]
 
     FlightOperation:
       type: object
@@ -442,7 +490,7 @@ components:
           properties:
             flightGoAheadIndicator:
               type: boolean
-              description: The GO (true) / NO-GO (false) indication for the flight operation based on the risk assessment
+              description: The go-ahead indication for the flight operation based on the risk assessment
             overallWeightedRisk:
               type: number
               format: double

--- a/RiskAssessmentApiChangelist.txt
+++ b/RiskAssessmentApiChangelist.txt
@@ -1,2 +1,5 @@
+Version 0.2.0
+- Enhanced for go/no-go related capability
+
 Version 0.1.0
 - Inception of Risk Assessment API

--- a/RiskAssessmentApiChangelist.txt
+++ b/RiskAssessmentApiChangelist.txt
@@ -1,5 +1,7 @@
 Version 0.2.0
-- Enhanced for go/no-go related capability
+- Enhanced for risk assessment endpoint for Flight Go-Ahead Indicator, plus supporting artifacts
+- Added endpoint for retrieving flight operation by UUID
+- Added endpoint for retrieving raw risk results
 
 Version 0.1.0
 - Inception of Risk Assessment API


### PR DESCRIPTION
Revision to add Flight Go-Ahead Indicator calculation result and supporting summary data to the Risk Assessment.

Also added an endpoint for querying just the Flight Operation and an endpoint for querying the Risk Assessment's raw results.

[risk_assessment_example_rev2.json](https://github.com/user-attachments/files/20731574/risk_assessment_example_rev2.json)


Angelo is responsible for making sure I did not miss anything from his prototype.

I am open to any and all suggestions.

Note: Swagger will warning about sibling elements with $refs being ignored, but the descriptions are helpful for developers. 