### PR TITLE
Risk assessemnt api hotfix

### DIFF
--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -388,7 +388,6 @@ components:
           format: double
           minimum: 0
           description: The threshold for the number of obstacles within the minimum distance
-      additionalProperties: true
       required:
       - minimumDistanceMeters
       - obstacleCount
@@ -403,7 +402,6 @@ components:
           minimum: 0.0
           maximum: 1.0
           description: The threshold for the probability of casualty for ground impact impact
-      additionalProperties: true
       required:
       - probabilityOfCasualty
 
@@ -427,7 +425,6 @@ components:
           minimum: 0.0
           maximum: 1.0
           description: The threshold for the weighted risk which incorporates satellite count, PDOP, and map tile availability
-      additionalProperties: true
       required:
       - satelliteCount
       - pdop
@@ -447,7 +444,6 @@ components:
             highThresholds:
               $ref: '#/components/schemas/ObstacleProximityRiskThresholds'
               description: A collection of thresholds for setting obstacle proximity risk level to HIGH
-          additionalProperties: true
           required:
           - mediumThresholds
           - highThresholds
@@ -461,7 +457,6 @@ components:
             highThresholds:
               $ref: '#/components/schemas/GroundImpactRiskThresholds'
               description: A collection of thresholds for setting ground impact risk level to HIGH
-          additionalProperties: true
           required:
           - mediumThresholds
           - highThresholds
@@ -497,7 +492,6 @@ components:
                   minimum: 0.0
                   maximum: 1.0
                   description: The weighting of map tile availability risk
-              additionalProperties: true
               required:
               - satelliteCount
               - pdop
@@ -505,7 +499,6 @@ components:
             forceHighRiskIfMapTileUnavailable:
               type: boolean
               description: The toggle for forcing navigation reliability risk level to HIGH if map tile is unavailable
-          additionalProperties: true
           required:
           - mediumThresholds
           - highThresholds
@@ -537,7 +530,6 @@ components:
                   minimum: 0.0
                   maximum: 1.0
                   description: The weighting of navigation reliability risk
-              additionalProperties: true
               required:
               - obstacleProximity
               - groundImpact
@@ -567,7 +559,6 @@ components:
               minimum: 0.0
               maximum: 1.0
               description: The threshold for the percentage of waypoints with an overall HIGH risk for setting Flight Go-Ahead Indicator to FALSE
-      additionalProperties: true
 
     FlightOperation:
       type: object
@@ -647,7 +638,6 @@ components:
           minimum: 0.0
           maximum: 100.0
           description: The percentage of waypoints receiving a HIGH or MEDIUM navigation reliability risk
-      additionalProperties: true
       required:
       - overallWeightedRisk
       - totalWaypointCount
@@ -679,7 +669,6 @@ components:
         navigationReliabilityRiskLevel:
           $ref: '#/components/schemas/RiskLevel'
           description: The navigation reliability risk level for the given waypoints
-      additionalProperties: true
       required:
       - waypoint
       - overallRiskLevel
@@ -706,7 +695,6 @@ components:
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
           description: The thresholds used for this risk assessment
-      additionalProperties: true
       required:
       - flightOperationUuid
       - flightGoAheadIndicator

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -710,7 +710,13 @@ components:
           type: string
           format: uuid
           description: The unique identifier of the flight operation for which the raw results were generated
-      additionalProperties: true
+        rawResults:
+          type: object
+          additionalProperties: true
+          description: The freeform risk assessment raw results
+      required:
+      - flightOperationUuid
+      - rawResults
 
   securitySchemes:
     OAuth2:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -83,7 +83,7 @@ paths:
       summary: Retrieve a flight operation for risk assessment
       operationId: getFlightOperationByUuid
       parameters:
-      - name: uuid
+      - name: operationUuid
         in: query
         description: The unique identifier of the flight operation
         schema:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -84,7 +84,7 @@ paths:
       operationId: getFlightOperationByUuid
       parameters:
       - name: uuid
-        in: path
+        in: query
         description: The unique identifier of the flight operation
         schema:
           type: string

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -111,7 +111,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         403:
-          description: Forbidden - client is not authorized to post flight operations
+          description: Forbidden - client is not authorized to query flight operations
           content:
             application/json:
               schema:
@@ -196,7 +196,7 @@ paths:
                 $ref: '#/components/schemas/Response'
       security:
       - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
-        
+
   /risk/v0/assessment/rawResults:
     get:
       tags:
@@ -217,9 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
-                description: The freeform risk assessment raw results
+                $ref: '#/components/schemas/RawResults'
         202:
           description: Accepted - risk assessment in progress
           content:
@@ -233,7 +231,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Response'
         403:
-          description: Forbidden - client is not authorized to query risk assessment reports
+          description: Forbidden - client is not authorized to query risk assessment raw results
           content:
             application/json:
               schema:
@@ -585,7 +583,7 @@ components:
         startTime:
           type: string
           format: date-time
-          description: The timestamp when the flight operation will start. Timestamp format is as specified by RFC 3339 section 5.6.
+          description: The timestamp when the flight operation will start. Timestamp format is as specified by RFC 3339 section 5.6
         vehicle:
           $ref: '#/components/schemas/Vehicle'
         waypoints:
@@ -604,12 +602,61 @@ components:
             $ref: '#/components/schemas/WindMeasurement'
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
-          description: The risk thresholds provided to override pre-configured thresholds.
-      additionalProperties: true
+          description: The risk thresholds provided to override pre-configured thresholds
       required:
       - startTime
       - vehicle
       - waypoints
+
+    RiskStatistics:
+      type: object
+      description: A collection of statistics for the risk assessment
+      properties:
+        overallWeightedRisk:
+          type: number
+          format: double
+          description: The weighted overall risk level
+        totalWaypointCount:
+          type: integer
+          format: int32
+          description: The total number of waypoints assessed for risk
+        highRiskWaypointCount:
+          type: integer
+          format: int32
+          description: The number of waypoints receiving a HIGH risk
+        mediumRiskWaypointCount:
+          type: integer
+          format: int32
+          description: The number of waypoints receiving a MEDIUM risk
+        lowRiskWaypointCount:
+          type: integer
+          format: int32
+          description: The number of waypoints receiving a LOW risk
+        obstacleProximityRiskyWaypointPercentage:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 100.0
+          description: The percentage of waypoints receiving a HIGH or MEDIUM obstacle proximity risk
+        groundImpactRiskyWaypointPercentage:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 100.0
+          description: The percentage of waypoints receiving a HIGH or MEDIUM ground impact risk
+        navigationReliabilityRiskyWaypointPercentage:
+          type: number
+          format: double
+          minimum: 0.0
+          maximum: 100.0
+          description: The percentage of waypoints receiving a HIGH or MEDIUM navigation reliability risk
+      additionalProperties: true
+      required:
+      - overallWeightedRisk
+      - totalWaypointCount
+      - highRiskWaypointCount
+      - mediumRiskWaypointCount
+      - lowRiskWaypointCount
 
     RiskLevel:
       type: string
@@ -652,54 +699,8 @@ components:
           type: boolean
           description: The go-ahead indication for the flight operation based on the risk assessment with TRUE meaning go-ahead and FALSE meaning do not go-ahead
         riskStatistics:
-          type: object
-          description: A collection of statistics for the risk assessment
-          properties:
-            overallWeightedRisk:
-              type: number
-              format: double
-              description: The weighted overall risk level
-            totalWaypointCount:
-              type: integer
-              format: int32
-              description: The total number of waypoints assessed for risk
-            highRiskWaypointCount:
-              type: integer
-              format: int32
-              description: The number of waypoints receiving a HIGH risk
-            mediumRiskWaypointCount:
-              type: integer
-              format: int32
-              description: The number of waypoints receiving a MEDIUM risk
-            lowRiskWaypointCount:
-              type: integer
-              format: int32
-              description: The number of waypoints receiving a LOW risk
-            obstacleProximityRiskyWaypointPercentage:
-              type: number
-              format: double
-              minimum: 0.0
-              maximum: 100.0
-              description: The percentage of waypoints receiving a HIGH or MEDIUM obstacle proximity risk
-            groundImpactRiskyWaypointPercentage:
-              type: number
-              format: double
-              minimum: 0.0
-              maximum: 100.0
-              description: The percentage of waypoints receiving a HIGH or MEDIUM ground impact risk
-            navigationReliabilityRiskyWaypointPercentage:
-              type: number
-              format: double
-              minimum: 0.0
-              maximum: 100.0
-              description: The percentage of waypoints receiving a HIGH or MEDIUM navigation reliability risk
-          additionalProperties: true
-          required:
-          - overallWeightedRisk
-          - totalWaypointCount
-          - highRiskWaypointCount
-          - mediumRiskWaypointCount
-          - lowRiskWaypointCount
+          $ref: '#/components/schemas/RiskStatistics'
+          description: The statistics for this risk assessment
         riskResults:
           type: array
           description: An ordered list of waypoints making up the flight operation and their associated risk levels
@@ -707,7 +708,7 @@ components:
             $ref: '#/components/schemas/RiskResults'
         riskThresholds:
           $ref: '#/components/schemas/RiskThresholds'
-          description: The thresholds used for this risk assessment.
+          description: The thresholds used for this risk assessment
       additionalProperties: true
       required:
       - flightOperationUuid
@@ -715,6 +716,11 @@ components:
       - riskStatistics
       - riskResults
       - riskThresholds
+
+    RawResults:
+      type: object
+      description: A freeform object for risk assessment raw results
+      additionalProperties: true
 
   securitySchemes:
     OAuth2:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -719,7 +719,12 @@ components:
 
     RawResults:
       type: object
-      description: A freeform object for risk assessment raw results
+      description: A freeform object for risk assessment raw results, plus associated flight operation unique identifier
+      properties:
+        flightOperationUuid:
+          type: string
+          format: uuid
+          description: The unique identifier of the flight operation for which the raw results were generated
       additionalProperties: true
 
   securitySchemes:

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -77,7 +77,6 @@ paths:
       security:
       - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
 
-  /risk/v0/operation/{uuid}:
     get:
       tags:
       - Risk Assessment

--- a/RiskAssessmentApi.yaml
+++ b/RiskAssessmentApi.yaml
@@ -307,7 +307,6 @@ components:
           format: double
           minimum: 0.0
           description: The default speed of the vehicle in meters per second. It may be overridden by a speed value for a waypoint
-      additionalProperties: true
       required:
       - uuid
       - type
@@ -345,7 +344,6 @@ components:
           format: double
           minimum: 0.0
           description: The speed of the vehicle as it travels from this waypoint to the next waypoint in meters per second. If not provided, the default speed of the vehicle may be used
-      additionalProperties: true
       required:
       - latitude
       - longitude
@@ -371,7 +369,6 @@ components:
           format: double
           minimum: 0.0
           description: The speed of the wind in meters per second
-      additionalProperties: true
       required:
       - altitudeMetersMsl
       - directionDegrees


### PR DESCRIPTION
Changes to support implementation of recent Inc 1 API revisions
- Removal of additionalProperties, due to code generation issues
- Creation of distinct types for RiskStatistics and RawResults, due to code generation issues
- Move to query style for GET Flight Operation param, for consitency with other GET endpoints
- Small improvements to descriptions and similar

NOTE: This API version has not gone anywhere, so I am not bumping the version!