### PR TITLE
FRAIHM-3752 All getting components by relationship from a source component

### DIFF
--- a/FraihmworkHealthAndIntegrityApi.yaml
+++ b/FraihmworkHealthAndIntegrityApi.yaml
@@ -1082,6 +1082,85 @@ paths:
       security:
       - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
 
+  /monitor/v1/component/{uuid}/relationship:
+    get:
+      tags:
+      - Monitor
+      - Components
+      summary: Retrieve all components that have a relationship with the given component
+      description: Returns all components that have a relationship with the given component, can optionally filter by specific relation types and if the related component is a source or target.
+      operationId: getComponentsByRelationship
+      parameters:
+      - name: uuid
+        in: path
+        description: The UUID of the component to get related components for
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: type
+        in: query
+        description: Filter results by the type of relationship. The string should match an existing RelationshipDefinition name.
+        schema:
+          type: string
+      - name: role
+        in: query
+        description: Filter by the role of the component in the relationship
+        schema:
+          type: string
+          enum:
+          - source
+          - target
+          - any
+          default: any
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActiveComponent'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        401:
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        403:
+          description: Forbidden - client is not authorized to read this component
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        404:
+          description: Component not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        406:
+          description: Not acceptable - only responds in application/json format
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+        500:
+          description: Server error
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+      security:
+      - OAuth2: [fraihmwork.component.read, fraihmwork.component.write, fraihmwork.component.admin]
+
   /monitor/v1/relationship/definition:
     get:
       tags:

--- a/FraihmworkHealthAndIntegrityApi.yaml
+++ b/FraihmworkHealthAndIntegrityApi.yaml
@@ -1082,7 +1082,7 @@ paths:
       security:
       - OAuth2: [fraihmwork.component.write, fraihmwork.component.admin]
 
-  /monitor/v1/component/{uuid}/relationship:
+  /monitor/v1/component/{uuid}/queryRelationship:
     get:
       tags:
       - Monitor
@@ -1100,7 +1100,7 @@ paths:
           format: uuid
       - name: type
         in: query
-        description: Filter results by the type of relationship. The string should match an existing RelationshipDefinition name.
+        description: Filter results by the type of relationship. The string should match an existing RelationshipDefinition name or null to not filter
         schema:
           type: string
       - name: role

--- a/FraihmworkHealthAndIntegrityApiChangelist.txt
+++ b/FraihmworkHealthAndIntegrityApiChangelist.txt
@@ -1,3 +1,6 @@
+Version 1.6.1
+- Added GET /monitor/v1/component/{uuid}/relationship: to allow querying associated components to a given one by its relationships
+
 Version 1.6.0
 - Added RelationshipDefinition and RelationshipInstance data types
 - Added POST, GET, and DELETE endpoints for RelationshipDefinitions

--- a/FraihmworkHealthAndIntegrityApiChangelist.txt
+++ b/FraihmworkHealthAndIntegrityApiChangelist.txt
@@ -1,5 +1,5 @@
 Version 1.6.1
-- Added GET /monitor/v1/component/{uuid}/relationship: to allow querying associated components to a given one by its relationships
+- Added GET /monitor/v1/component/{uuid}/queryRelationship: to allow querying associated components to a given one by its relationships
 
 Version 1.6.0
 - Added RelationshipDefinition and RelationshipInstance data types


### PR DESCRIPTION
This PR introduces a new monitoring endpoint that allows a client to get all associated components based on if they have a relationship with the given component.

The client may also filter on specific relationship types and if the associated components should be sources, targets, or any role.

**Review:**

1. Checkout this branch
2. Enter the contents of the `FraihmworkHealthAndIntegrityApi.yaml` into https://editor.swagger.io/
3. View the new endpoint under the components section

Additional notes: I considered adding endpoints that would return relationship definitions instead of components, this could be useful but is outside of the scope of the story and I couldn't think of a use case for it right now so left it out of this PR

Screenshot of the new endpoint on swagger
<img width="734" height="638" alt="image" src="https://github.com/user-attachments/assets/2e49c588-dd89-4c43-88ca-100f7d46e5f8" />
